### PR TITLE
Add find by corredor

### DIFF
--- a/src/constants/allowedTypes.js
+++ b/src/constants/allowedTypes.js
@@ -1,5 +1,6 @@
 export default [
   'linhas',
   'paradas',
-  'paradasPorLinha'
+  'paradasPorLinha',
+  'corredor'
 ]

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -7,16 +7,19 @@ export default {
   linhas: {
     route: '/linha/buscar',
     param: 'termosBusca',
-    libParamName: 'term'
+    proxyParam: 'term'
   },
   paradas: {
     route: '/parada/buscar',
     param: 'termosBusca',
-    libParamName: 'term'
+    proxyParam: 'term'
   },
   paradasPorLinha: {
     route: '/parada/buscarParadasPorLinha',
     param: 'codigoLinha',
-    libParamName: 'code'
+    proxyParam: 'code'
+  },
+  corredor: {
+    route: '/corredor'
   }
 }

--- a/src/find.js
+++ b/src/find.js
@@ -5,63 +5,74 @@ const handleError = err => {
   throw new Error(err)
 }
 
-const hasParams = params =>
-  params || handleError('O método "find" deve receber parâmetros.')
+const hasOptions = options =>
+  options || handleError('O método "find" deve receber um objeto com opções.')
 
-const hasAllowedType = params => {
-  ALLOWED_TYPES.includes(params.type) || handleError('O parâmetro "type" está errado.')
-  return params
+const hasAllowedType = options => {
+  ALLOWED_TYPES.includes(options.type) || handleError(`O "type" "${options.type}" não existe.`)
+  return options
 }
 
-const hasLibParamNameForThisType = params => {
-  const libParamName = API[params.type].libParamName
-  params[libParamName] || handleError(`O parâmetro "${libParamName}" é obrigatório para este "type".`)
+const hasProxyParamForThisType = options => {
+  const apiType = API[options.type]
+  if (!apiType.param) return options
 
-  const updatedParams = params
-  updatedParams.value = params[libParamName]
+  const proxyParam = apiType.proxyParam
+  options[proxyParam] || handleError(`O "${proxyParam}" é obrigatório para este "type".`)
 
-  return updatedParams
+  const updatedOptions = Object.assign(options, {
+    paramValue: options[proxyParam]
+  })
+
+  return updatedOptions
 }
 
-const fetchData = params => {
-  const { auth, type, value } = params
+const validateHttpStatus = res => {
+  res.status === 200 || handleError('Erro ao se conectar com o serviço da SPTrans.')
+  return res
+}
 
-  const validateHttpStatus = res => {
-    res.status === 200 || handleError('Erro ao se conectar com o serviço da SPTrans.')
-    return res
-  }
+const handleResponse = res => res.data
 
-  const handleResponse = res => res.data
+const fetchData = options => {
+  const { auth, type, paramValue } = options
 
-  const buildPromise = paramValue => {
-    const config = {
+  const buildPromise = value => {
+    let config = {
       method: 'get',
       url: API.endpoint + API[type].route,
-      params: {
-        [API[type].param]: paramValue
-      },
       headers: {
         Cookie: auth
       }
     }
+
+    if (value) {
+      const apiParam = API[type].param
+      config = Object.assign(config, {
+        params: {
+          [apiParam]: value
+        }
+      })
+    }
+
     return axios(config)
   }
 
-  if (value instanceof Array) {
-    const promises = value.map(buildPromise)
+  if (paramValue instanceof Array) {
+    const promises = paramValue.map(buildPromise)
     return Promise.all(promises)
       .then(res => res.map(validateHttpStatus))
       .then(res => res.map(handleResponse))
   }
 
-  return buildPromise(value)
+  return buildPromise(paramValue)
     .then(validateHttpStatus)
     .then(handleResponse)
 }
 
-export default params =>
-  Promise.resolve(params)
-    .then(hasParams)
+export default options =>
+  Promise.resolve(options)
+    .then(hasOptions)
     .then(hasAllowedType)
-    .then(hasLibParamNameForThisType)
+    .then(hasProxyParamForThisType)
     .then(fetchData)

--- a/test/integration/find.test.js
+++ b/test/integration/find.test.js
@@ -68,3 +68,13 @@ test('find paradasPorLinha passing an array of integers should return a populate
   t.true(response.length === 3)
   t.true(response instanceof Array)
 })
+
+test('find corredores should return a populated array', async t => {
+  const auth = await sptrans.auth(TOKEN)
+  const response = await sptrans.find({
+    auth,
+    type: 'corredor'
+  })
+  t.true(response.length > 0)
+  t.true(response instanceof Array)
+})


### PR DESCRIPTION
This PR adds a search by 'corredor' that returns all 'corredores'.

Other changes:

- Some refactorings were done on find() method code as a name change from 'libParamName' to 'proxyParam' and 'params' to 'options' for better readable and understanding.

- Error messages



